### PR TITLE
GKImageCropViewController: Move the logic to hide the NavigationBar  from viewDidLoad to viewWillAppear:animated:

### DIFF
--- a/GKClasses/GKImageCropViewController.m
+++ b/GKClasses/GKImageCropViewController.m
@@ -173,9 +173,12 @@
     [self _setupNavigationBar];
     [self _setupCropView];
     [self _setupToolbar];
+}
 
+- (void)viewWillAppear:(BOOL)animated{
+    [super viewWillAppear:animated];
     if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
-        [self.navigationController setNavigationBarHidden:YES];
+      [self.navigationController setNavigationBarHidden:YES animated:animated];
     }
 }
 


### PR DESCRIPTION
I found that when pushing a GKImageCropViewController onto a UINavigationController stack that is not a UIImagePickerController the animation is off. Presumably UIImagePickerController is doing something in it's viewWillDissapear:animated: implementation.

By moving the line to hide the NavigationBar to viewWillAppear:animated: GKImageCropViewController will animated well when we push it onto a UIImagePickerController or a regular UINaviationController stack.
