### PR TITLE
some adjustment for scale calculation in croppedImage

### DIFF
--- a/GKClasses/GKImageCropOverlayView.m
+++ b/GKClasses/GKImageCropOverlayView.m
@@ -67,8 +67,8 @@
         [[UIColor whiteColor] set];
         [NSLocalizedString(@"GKImoveAndScale", @"") drawInRect:CGRectMake(10, (height - heightSpan) + (heightSpan / 2 - 20 / 2) , width - 20, 20) 
                                                    withFont:[UIFont boldSystemFontOfSize:20] 
-                                              lineBreakMode:UILineBreakModeTailTruncation 
-                                                  alignment:UITextAlignmentCenter];
+                                              lineBreakMode:NSLineBreakByTruncatingTail
+                                                  alignment:NSTextAlignmentCenter];
         
     }
 }

--- a/GKClasses/GKImageCropView.m
+++ b/GKClasses/GKImageCropView.m
@@ -11,7 +11,6 @@
 #import "GKResizeableCropOverlayView.h"
 
 #import <QuartzCore/QuartzCore.h>
-
 #define rad(angle) ((angle) / 180.0 * M_PI)
 
 static CGRect GKScaleRect(CGRect rect, CGFloat scale)
@@ -75,7 +74,16 @@ static CGRect GKScaleRect(CGRect rect, CGFloat scale)
 }
 
 - (void)setCropSize:(CGSize)cropSize{
-    
+
+  
+  CGFloat ratioWidth1 = self.bounds.size.width / cropSize.width;
+  CGFloat ratioWidth2 = cropSize.width / self.bounds.size.width;
+  CGFloat ratioHeight1 = self.bounds.size.height / cropSize.height;
+  CGFloat ratioHeight2 = cropSize.height / self.bounds.size.height;
+  CGFloat ratio = MIN(MIN(ratioWidth1, ratioWidth2), MIN(ratioHeight1, ratioHeight2));
+ 	cropSize = CGSizeMake(cropSize.width*ratio, cropSize.height * ratio);
+
+  
     if (self.cropOverlayView == nil){
         if(self.resizableCropArea)
             self.cropOverlayView = [[GKResizeableCropOverlayView alloc] initWithFrame:self.bounds andInitialContentSize:CGSizeMake(cropSize.width, cropSize.height)];
@@ -93,7 +101,6 @@ static CGRect GKScaleRect(CGRect rect, CGFloat scale)
 
 #pragma mark -
 #pragma Public Methods
-
 - (UIImage *)croppedImage{
     
     //renders the the zoomed area into the cropped image
@@ -114,14 +121,20 @@ static CGRect GKScaleRect(CGRect rect, CGFloat scale)
     else {
 		
 		//scaled width/height in regards of real width to crop width
-		CGFloat scaleWidth = self.imageToCrop.size.width / self.cropSize.width;
-		CGFloat scaleHeight = self.imageToCrop.size.height / self.cropSize.height;
-		CGFloat scale = MAX(scaleWidth, scaleHeight);
-		
+			CGFloat scaleWidth = self.imageToCrop.size.width / self.cropSize.width;
+			CGFloat scaleHeight = self.imageToCrop.size.height / self.cropSize.height;
+  	  CGFloat scale = 0.0;
+      if (self.cropSize.width>self.cropSize.height) {
+      	  scale = self.imageToCrop.size.width < self.imageToCrop.size.height ? MAX(scaleWidth, scaleHeight) : MIN(scaleWidth, scaleHeight);
+      }else{
+        scale = self.imageToCrop.size.width < self.imageToCrop.size.height ? MIN(scaleWidth, scaleHeight) : MAX(scaleWidth, scaleHeight);
+      }
+    	
+
 		//extract visible rect from scrollview and scale it 
 		CGRect visibleRect = [scrollView convertRect:scrollView.bounds toView:imageView];
 		visibleRect = GKScaleRect(visibleRect, scale);
-		
+      
 		//transform visible rect to image orientation
 		CGAffineTransform rectTransform = [self _orientationTransformedRectOfImage:self.imageToCrop];
 		visibleRect = CGRectApplyAffineTransform(visibleRect, rectTransform);

--- a/GKClasses/GKImageCropViewController.m
+++ b/GKClasses/GKImageCropViewController.m
@@ -62,7 +62,7 @@
 
 
 - (void)_setupCropView{
-    
+
     self.imageCropView = [[GKImageCropView alloc] initWithFrame:self.view.bounds];
     [self.imageCropView setImageToCrop:sourceImage];
     [self.imageCropView setResizableCropArea:self.resizeableCropArea];
@@ -171,7 +171,6 @@
     self.title = NSLocalizedString(@"GKIchoosePhoto", @"");
 
     [self _setupNavigationBar];
-    [self _setupCropView];
     [self _setupToolbar];
 
     if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
@@ -197,5 +196,8 @@
 {
     return (interfaceOrientation == UIInterfaceOrientationPortrait);
 }
-
+-(void)viewDidAppear:(BOOL)animated{
+  [super viewDidAppear:animated];
+  [self _setupCropView];
+}
 @end


### PR DESCRIPTION
Thanks for creating this open source plugin. I really like it. 

I added some code to handle cropping image when the orientation and crop rectangle in opposite situation. (Portrait Image with Landscape Crop rectangle or vice versa)

if (self.cropSize.width>self.cropSize.height) {
          scale = self.imageToCrop.size.width < self.imageToCrop.size.height ? MAX(scaleWidth, scaleHeight) : MIN(scaleWidth, scaleHeight);
      }else{
        scale = self.imageToCrop.size.width < self.imageToCrop.size.height ? MIN(scaleWidth, scaleHeight) : MAX(scaleWidth, scaleHeight);
      }
