### PR TITLE
Fixed NSFoundationVersionNumber checking to allow compilation on Xcode 4

### DIFF
--- a/GKClasses/GKImageCropViewController.m
+++ b/GKClasses/GKImageCropViewController.m
@@ -9,6 +9,10 @@
 #import "GKImageCropViewController.h"
 #import "GKImageCropView.h"
 
+#ifndef NSFoundationVersionNumber_iOS_6_1
+#define NSFoundationVersionNumber_iOS_6_1 993.00
+#endif
+
 @interface GKImageCropViewController ()
 
 @property (nonatomic, strong) GKImageCropView *imageCropView;


### PR DESCRIPTION
The constant `NSFoundationVersionNumber_iOS_6_1` is undefined in Xcode 4 (NSObjCRuntime.h), which prevents compilation.

List of constants are available [here](https://developer.apple.com/library/ios/documentation/cocoa/reference/foundation/Miscellaneous/Foundation_Constants/Reference/reference.html) for reference.
